### PR TITLE
Add compatibility for multiple 4chan archivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 MoeSearch
 =========
 
-A Python library for [desuarchive.org](http://desuarchive.org/) (dump retrived from archive.moe, that was previously known as FoolzArchive) REST API.  
-To be fair, actually it should work with every installation of FoolFuuka, but you have to try that.
+A Python library for [desuarchive.org](https://desuarchive.org/) and [RebeccaBlackTech](https://rbt.asia) REST API.  
+Theoretically, it should work with every installation of FoolFuuka, but 4plebs apparently needs to be fixed to their updated definition of the FoolFuuka API before it will work.
 
 Helpful binaries included.
 
-Fixed from the [moesearch](https://pypi.org/project/moesearch/) library, which became broken due to a hardcoded domain. We plan to make the URL a constructor argument (so you can use it with 4plebs, rbt.asia, though not warosu, which is fuuka). We also plan to make this compatible with [the 4plebs definition of the FoolFuuka API.](https://4plebs.tech/foolfuuka/)
-
-BEWARE
+Disclaimer
 ------
 
+This codebase was fixed from the [moesearch](https://pypi.org/project/moesearch/) library, which became broken due to a hardcoded domain. We made the URL a function argument (so you can use it with rbt.asia, though not warosu, which is fuuka). We also plan to make this compatible with [the 4plebs definition of the FoolFuuka API.](https://4plebs.tech/foolfuuka/) Finally we have to fix the unit tests to work on whatever method we use to set `archiver_url`.
+
 This software is experimental, use it at your own risk.
-For those who want to try this...  
-[PyPI archive](https://pypi.python.org/pypi/moesearch/)
 
 Quickstart
 --------
@@ -22,14 +20,14 @@ Quickstart
 FoolFuuka docs are available [at foolz.us](https://web.archive.org/web/20140728111047/http://www.foolz.us/docs/foolfuuka/documentation.html).  
 ```py
 >>> import moesearch
->>> print(moesearch.search(board="a", text="woxxy")[2].comment)
+>>> print(moesearch.search(archiver_url="https://desuarchive.org", board="a", text="woxxy")[2].comment)
 >>112732805
 Fuck Woxxy.
->>> print(moesearch.index("a", 1)["112834776"].op.media.media_link)
-http://data.archive.moe/board/a/image/1366/74/1366741186747.jpg
->>> print(moesearch.post("a", 112766871).board.short_name)
+>>> print(archiver_url="https://desuarchive.org", moesearch.index("a", 1)["112834776"].op.media.media_link)
+http://cdn2.desu-usergeneratedcontent.xyz/a/image/1366/74/1366741186747.jpg
+>>> print(archiver_url="https://desuarchive.org", moesearch.post("a", 112766871).board.short_name)
 a
->>> print(moesearch.thread("a", 112800651).posts[0].comment)
+>>> print(moesearch.thread(archiver_url="https://desuarchive.org", "a", 112800651).posts[0].comment)
 >>112800651
 I fucking went grocery shopping all the time when I was a kid. I didn't have qt lesbian friends to go with though.
 ```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ a
 >>112800651
 I fucking went grocery shopping all the time when I was a kid. I didn't have qt lesbian friends to go with though.
 ```
+
+LICENSE
+-------
+
+```
+        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+                    Version 2, December 2004 
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+
+ Everyone is permitted to copy and distribute verbatim or modified 
+ copies of this license document, and changing it is allowed as long 
+ as the name is changed. 
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MoeSearch
 =========
 
-A Python library for [desuarchive.org](https://desuarchive.org/) and [RebeccaBlackTech](https://rbt.asia) REST API.  
+A Python library for [desuarchive.org](https://desuarchive.org/), [RebeccaBlackTech](https://rbt.asia), [archive.4plebs.org](https://archive.4plebs.org) REST API.  
 Theoretically, it should work with every installation of FoolFuuka, but 4plebs apparently needs to be fixed to their updated definition of the FoolFuuka API before it will work.
 
 Helpful binaries included.
@@ -9,7 +9,7 @@ Helpful binaries included.
 Disclaimer
 ------
 
-This codebase was fixed from the [moesearch](https://pypi.org/project/moesearch/) library, which became broken due to a hardcoded domain. We made the URL a function argument (so you can use it with rbt.asia, though not warosu, which is fuuka). We also plan to make this compatible with [the 4plebs definition of the FoolFuuka API.](https://4plebs.tech/foolfuuka/) Finally we have to fix the unit tests to work on whatever method we use to set `archiver_url`.
+This codebase was fixed from the [moesearch](https://pypi.org/project/moesearch/) library, which became broken due to a hardcoded domain. We made the URL a function argument (so you can use it with rbt.asia, though not warosu, which is fuuka). Finally we have to fix the unit tests to work on whatever method we use to set `archiver_url`.
 
 This software is experimental, use it at your own risk.
 
@@ -17,7 +17,7 @@ Quickstart
 --------
 
 (You can check the executables in /bin folder).
-FoolFuuka docs are available [at foolz.us](https://web.archive.org/web/20140728111047/http://www.foolz.us/docs/foolfuuka/documentation.html).  
+FoolFuuka API docs are available [at 4plebs.org.](https://4plebs.tech/foolfuuka/).  
 ```py
 >>> import moesearch
 >>> print(moesearch.search(archiver_url="https://desuarchive.org", board="a", text="woxxy")[2].comment)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 MoeSearch
 =========
 
-A stupid Python library for [desustorage.org](http://desustorage.org/) (dump retrived from archive.moe, that was previously known as FoolzArchive) REST API.  
+A Python library for [desuarchive.org](http://desuarchive.org/) (dump retrived from archive.moe, that was previously known as FoolzArchive) REST API.  
 To be fair, actually it should work with every installation of FoolFuuka, but you have to try that.
 
-Useless binaries included.
+Helpful binaries included.
+
+Fixed from the [moesearch](https://pypi.org/project/moesearch/) library, which became broken due to a hardcoded domain. We plan to make the URL a constructor argument (so you can use it with 4plebs, rbt.asia, though not warosu, which is fuuka). We also plan to make this compatible with [the 4plebs definition of the FoolFuuka API.](https://4plebs.tech/foolfuuka/)
 
 BEWARE
 ------

--- a/moesearch/api.py
+++ b/moesearch/api.py
@@ -10,10 +10,11 @@ from pprint import pprint
 #urllib3 being missing.
 requests.packages.urllib3.disable_warnings()
 
-DESUSTORAGE_API_URL = "https://desuarchive.org/_/api/chan"
+ARCHIVER_URL = "https://desuarchive.org"
+FOOLFUUKA_API_URL = "%s/_/api/chan" % ARCHIVER_URL
 
 def index(board, page=1):
-  req = requests.get("{}/index".format(DESUSTORAGE_API_URL),
+  req = requests.get("{}/index".format(FOOLFUUKA_API_URL),
           stream=False, verify=False,
           params = {"board": str(board), "page": int(page)})
   #print(req.content)
@@ -25,7 +26,7 @@ def index(board, page=1):
   return res 
 
 def search(board, **kwargs):
-  url = "{}/search".format(DESUSTORAGE_API_URL)
+  url = "{}/search".format(FOOLFUUKA_API_URL)
   try:
     kwargs["boards"] = board.lower() #it's a string?
   except AttributeError:
@@ -42,7 +43,7 @@ def search(board, **kwargs):
   return [Post(post_obj) for post_obj in res["posts"]]
 
 def thread(board, thread_num, latest_doc_id=-1, last_limit=-1):
-  url = "{}/thread".format(DESUSTORAGE_API_URL)
+  url = "{}/thread".format(FOOLFUUKA_API_URL)
   payload = {"board": str(board), "num": thread_num}
   if(latest_doc_id != -1):
     payload["latest_doc_id"] = (int(latest_doc_id))
@@ -55,7 +56,7 @@ def thread(board, thread_num, latest_doc_id=-1, last_limit=-1):
   return Thread(res)
 
 def post(board, post_num):
-  req = requests.get("{}/post".format(DESUSTORAGE_API_URL),
+  req = requests.get("{}/post".format(FOOLFUUKA_API_URL),
                   verify=True,  stream=False,
                   params={"board":str(board), "num":post_num})
   res = req.json()

--- a/moesearch/api.py
+++ b/moesearch/api.py
@@ -10,11 +10,12 @@ from pprint import pprint
 #urllib3 being missing.
 requests.packages.urllib3.disable_warnings()
 
-ARCHIVER_URL = "https://desuarchive.org"
-FOOLFUUKA_API_URL = "%s/_/api/chan" % ARCHIVER_URL
+# archiver_url is now an argument, so you can use https://archived.moe, https://rbt.asia, or https://4plebs.org
+#archiver_url = "https://desuarchive.org"
+FOOLFUUKA_API_URL = "%s/_/api/chan"
 
-def index(board, page=1):
-  req = requests.get("{}/index".format(FOOLFUUKA_API_URL),
+def index(archiver_url, board, page=1):
+  req = requests.get("{}/index".format(FOOLFUUKA_API_URL % archiver_url),
           stream=False, verify=False,
           params = {"board": str(board), "page": int(page)})
   #print(req.content)
@@ -25,8 +26,8 @@ def index(board, page=1):
     res[thread_num] = IndexResult(res[thread_num])
   return res 
 
-def search(board, **kwargs):
-  url = "{}/search".format(FOOLFUUKA_API_URL)
+def search(archiver_url, board, **kwargs):
+  url = "{}/search".format(FOOLFUUKA_API_URL % archiver_url)
   try:
     kwargs["boards"] = board.lower() #it's a string?
   except AttributeError:
@@ -42,8 +43,8 @@ def search(board, **kwargs):
   res = res['0']
   return [Post(post_obj) for post_obj in res["posts"]]
 
-def thread(board, thread_num, latest_doc_id=-1, last_limit=-1):
-  url = "{}/thread".format(FOOLFUUKA_API_URL)
+def thread(archiver_url, board, thread_num, latest_doc_id=-1, last_limit=-1):
+  url = "{}/thread".format(FOOLFUUKA_API_URL % archiver_url)
   payload = {"board": str(board), "num": thread_num}
   if(latest_doc_id != -1):
     payload["latest_doc_id"] = (int(latest_doc_id))
@@ -55,8 +56,8 @@ def thread(board, thread_num, latest_doc_id=-1, last_limit=-1):
     raise ArchiveException(res)
   return Thread(res)
 
-def post(board, post_num):
-  req = requests.get("{}/post".format(FOOLFUUKA_API_URL),
+def post(archiver_url, board, post_num):
+  req = requests.get("{}/post".format(FOOLFUUKA_API_URL % archiver_url),
                   verify=True,  stream=False,
                   params={"board":str(board), "num":post_num})
   res = req.json()

--- a/moesearch/api.py
+++ b/moesearch/api.py
@@ -10,7 +10,7 @@ from pprint import pprint
 #urllib3 being missing.
 requests.packages.urllib3.disable_warnings()
 
-DESUSTORAGE_API_URL = "https://desustorage.org/_/api/chan"
+DESUSTORAGE_API_URL = "https://desuarchive.org/_/api/chan"
 
 def index(board, page=1):
   req = requests.get("{}/index".format(DESUSTORAGE_API_URL),
@@ -38,7 +38,7 @@ def search(board, **kwargs):
   res = req.json()
   if ArchiveException.is_error(res):
     raise ArchiveException(res)
-  res = res[0]
+  res = res['0']
   return [Post(post_obj) for post_obj in res["posts"]]
 
 def thread(board, thread_num, latest_doc_id=-1, last_limit=-1):

--- a/tests.py
+++ b/tests.py
@@ -76,7 +76,7 @@ class TestPost(unittest.TestCase):
 
   def test_media_data(self):
     """ check media data are correct for the media post """
-    self.assertEqual("https://data.desustorage.org/fit/image/1444/85/1444858212551.jpg", self.media_post.media.media_link)
+    self.assertEqual("https://cdn2.desu-usergeneratedcontent.xyz/fit/image/1444/85/1444858212551.jpg", self.media_post.media.media_link)
 
   def test_no_comment(self):
     """ if a post has no comment, it has to have an image/webm! """


### PR DESCRIPTION
Your moesearch library was hardcoded to work with only one 4chan archiver whose URL has changed. Now we add a command line argument allowing users to use any FoolFuuka based 4chan archiver (not warosu).